### PR TITLE
[Fabric][CommandBar] Fix wrong type for renderIcon

### DIFF
--- a/libs/fabric/package.json
+++ b/libs/fabric/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/package.schema.json",
   "name": "@angular-react/fabric",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "ngPackage": {
     "lib": {
       "entryFile": "public-api.ts",

--- a/libs/fabric/src/lib/components/command-bar/command-bar.component.ts
+++ b/libs/fabric/src/lib/components/command-bar/command-bar.component.ts
@@ -1,31 +1,13 @@
 import { InputRendererOptions, Omit, ReactWrapperComponent } from '@angular-react/core';
-import {
-  AfterContentInit,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  ContentChild,
-  ElementRef,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  Output,
-  QueryList,
-  ViewChild,
-} from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChild, ElementRef, EventEmitter, Input, OnDestroy, Output, QueryList, ViewChild } from '@angular/core';
 import { ICommandBarItemProps, ICommandBarProps } from 'office-ui-fabric-react/lib/CommandBar';
-import { IContextualMenuItemProps } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Subscription } from 'rxjs';
 import { OnChanges, TypedChanges } from '../../declarations/angular/typed-changes';
 import omit from '../../utils/omit';
 import { mergeItemChanges } from '../core/declarative/item-changed';
 import { CommandBarItemChangedPayload, CommandBarItemDirective } from './directives/command-bar-item.directives';
-import {
-  CommandBarFarItemsDirective,
-  CommandBarItemsDirective,
-  CommandBarItemsDirectiveBase,
-  CommandBarOverflowItemsDirective,
-} from './directives/command-bar-items.directives';
+import { CommandBarFarItemsDirective, CommandBarItemsDirective, CommandBarItemsDirectiveBase, CommandBarOverflowItemsDirective } from './directives/command-bar-items.directives';
 
 @Component({
   selector: 'fab-command-bar',
@@ -210,11 +192,9 @@ export class FabCommandBarComponent extends ReactWrapperComponent<ICommandBarPro
     return Object.assign(
       {},
       sharedProperties,
-      iconRenderer &&
-        ({ onRenderIcon: props => iconRenderer({ contextualMenuItemProps: props }) } as Pick<
-          ICommandBarItemProps,
-          'onRenderIcon'
-        >),
+      iconRenderer && {
+        onRenderIcon: (item: IContextualMenuItem) => iconRenderer({ contextualMenuItem: item }),
+      } as any /* NOTE: Fix for wrong typings of `onRenderIcon` in office-ui-fabric-react */,
       renderer &&
         ({ onRender: (item, dismissMenu) => renderer({ item, dismissMenu }) } as Pick<ICommandBarItemProps, 'onRender'>)
     ) as ICommandBarItemProps;
@@ -234,5 +214,5 @@ export interface ICommandBarItemOptionsRenderContext {
 }
 
 export interface ICommandBarItemOptionsRenderIconContext {
-  readonly contextualMenuItemProps: IContextualMenuItemProps;
+  readonly contextualMenuItem: IContextualMenuItem;
 }


### PR DESCRIPTION
`office-ui-fabric-react` has bad types set for `onRenderIcon` in `IContextualMenuItem`, at runtime the actual item is passed, and not its props.