### PR TITLE
Fix tree shaking removing code needed for handling `ng-content` in production builds

### DIFF
--- a/libs/core/src/lib/renderer/registry.ts
+++ b/libs/core/src/lib/renderer/registry.ts
@@ -3,9 +3,6 @@
 
 import * as React from 'react';
 
-import { Disguise } from './components/Disguise';
-import { ReactContent } from './react-content';
-
 export type ComponentResolver = () => React.ReactType;
 
 const elementMap = new Map<string, { resolver: ComponentResolver }>();
@@ -49,6 +46,3 @@ export function getComponentClass(elementName: string): React.ReactType {
     throw new TypeError(`Could not load component for: ${elementName}.${e}`);
   }
 }
-
-registerElement('ReactContent', () => ReactContent);
-registerElement('Disguise', () => Disguise);

--- a/libs/core/src/lib/renderer/renderer.ts
+++ b/libs/core/src/lib/renderer/renderer.ts
@@ -4,7 +4,10 @@
 import { Injectable, Renderer2, RendererStyleFlags2, RendererType2 } from '@angular/core';
 import { EventManager, ɵDomRendererFactory2, ɵDomSharedStylesHost } from '@angular/platform-browser';
 import { StringMap } from '../declarations/StringMap';
+import { Disguise } from './components/Disguise';
+import { ReactContent } from './react-content';
 import { isReactNode, ReactNode } from './react-node';
+import { registerElement } from './registry';
 
 const DEBUG = false;
 
@@ -79,7 +82,11 @@ export class ReactRenderer implements Renderer2 {
     },
   };
 
-  constructor(public readonly rootRenderer: AngularReactRendererFactory) {}
+  constructor(public readonly rootRenderer: AngularReactRendererFactory) {
+    // These two elements are essential for the whole experience to be smooth for the user - register them from the get-go.
+    registerElement('ReactContent', () => ReactContent);
+    registerElement('Disguise', () => Disguise);
+  }
 
   destroy(): void {}
 


### PR DESCRIPTION
Fixes #13 

Angular CLI's Webpack default seems to be pretty aggressive (or there's a bug in one of them), where it removes actual code that should be executed.
This manifested itself already in #8 (fixed by #9).

We need to account for this when writing code in the library - not to write any code that's going to be executed by just loading the scripts, since it may get removed.

Moving the registrations of both `Disguise` and `ReactContent` components to the `ReactRenderer` makes sense, since you're supposed to have one per app, and we're guaranteed that its `constructor` will get executed.

@benfeely Following this, it may be worth re-considering if we want to make the registry an actual Angular Service (i.e. `@Injectable`). We discussed this a few months ago but decided to leave it as-is then.