### PR TITLE
Upgrade office-ui-fabric-react to 6.73.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,7 @@
     "messagebar",
     "nrwl",
     "renderprop",
+    "scrollable",
     "submenu",
     "uifabric",
     "unmount",

--- a/libs/fabric/package.json
+++ b/libs/fabric/package.json
@@ -75,7 +75,7 @@
     "@angular/core": "^6.1.0",
     "@angular/platform-browser-dynamic": "^6.1.0",
     "@angular/platform-browser": "^6.1.0",
-    "office-ui-fabric-react": "6.43.0",
+    "office-ui-fabric-react": "6.73.0",
     "react-dom": "^16.4.1",
     "react": "^16.4.1"
   }

--- a/libs/fabric/src/lib/components/button/action-button.component.ts
+++ b/libs/fabric/src/lib/components/button/action-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/base-button.component.ts
+++ b/libs/fabric/src/lib/components/button/base-button.component.ts
@@ -49,7 +49,7 @@ export abstract class FabBaseButtonComponent extends ReactWrapperComponent<IButt
   @Input()
   secondaryText?: IButtonProps['secondaryText'];
   @Input()
-  toggled?: IButtonProps['toggled'];
+  toggled?: IButtonProps['toggle'];
   @Input()
   data?: IButtonProps['data'];
   @Input()

--- a/libs/fabric/src/lib/components/button/command-bar-button.component.ts
+++ b/libs/fabric/src/lib/components/button/command-bar-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/compound-button.component.ts
+++ b/libs/fabric/src/lib/components/button/compound-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/default-button.component.ts
+++ b/libs/fabric/src/lib/components/button/default-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/icon-button.component.ts
+++ b/libs/fabric/src/lib/components/button/icon-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/messagebar-button.component.ts
+++ b/libs/fabric/src/lib/components/button/messagebar-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/primary-button.component.ts
+++ b/libs/fabric/src/lib/components/button/primary-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/button/split-button.component.ts
+++ b/libs/fabric/src/lib/components/button/split-button.component.ts
@@ -31,7 +31,7 @@ import { FabBaseButtonComponent } from './base-button.component';
       [splitButtonAriaLabel]="splitButtonAriaLabel"
       [menuAs]="menuAs"
       [secondaryText]="secondaryText"
-      [toggled]="toggled"
+      [toggle]="toggle"
       [data]="data"
       [getClassNames]="getClassNames"
       [getSplitButtonClassNames]="getSplitButtonClassNames"

--- a/libs/fabric/src/lib/components/choice-group/choice-group.component.ts
+++ b/libs/fabric/src/lib/components/choice-group/choice-group.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IChoiceGroupOption, IChoiceGroupProps } from 'office-ui-fabric-react/lib/ChoiceGroup';
 
 @Component({
@@ -19,6 +29,7 @@ import { IChoiceGroupOption, IChoiceGroupProps } from 'office-ui-fabric-react/li
       [required]="required"
       [theme]="theme"
       [styles]="styles"
+      [ariaLabelledBy]="ariaLabelledBy"
       [Changed]="onChangedHandler"
       [Change]="onChangeHandler"
       >
@@ -45,6 +56,8 @@ export class FabChoiceGroupComponent extends ReactWrapperComponent<IChoiceGroupP
   theme?: IChoiceGroupProps['theme'];
   @Input()
   styles?: IChoiceGroupProps['styles'];
+  @Input()
+  ariaLabelledBy?: IChoiceGroupProps['ariaLabelledBy'];
 
   /** HTML Input props */
   @Input()

--- a/libs/fabric/src/lib/components/combo-box/base-combo-box.component.ts
+++ b/libs/fabric/src/lib/components/combo-box/base-combo-box.component.ts
@@ -3,7 +3,7 @@
 
 import { InputRendererOptions, JsxRenderFunc, ReactWrapperComponent } from '@angular-react/core';
 import { ChangeDetectorRef, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2 } from '@angular/core';
-import { IComboBoxOption, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
+import { IComboBox, IComboBoxOption, IComboBoxProps } from 'office-ui-fabric-react/lib/ComboBox';
 
 export abstract class FabBaseComboBoxComponent extends ReactWrapperComponent<IComboBoxProps> implements OnInit {
   @Input()
@@ -47,11 +47,11 @@ export abstract class FabBaseComboBoxComponent extends ReactWrapperComponent<ICo
   renderLowerContent?: InputRendererOptions<IComboBoxProps>;
 
   @Output()
-  readonly onChanged = new EventEmitter<{
+  readonly onChange = new EventEmitter<{
+    event: Event;
     option?: IComboBoxOption;
     index?: number;
     value?: string;
-    submitPendingValueEvent?: any;
   }>();
   @Output()
   readonly onPendingValueChanged = new EventEmitter<{ option?: IComboBoxOption; index?: number; value?: string }>();
@@ -68,7 +68,7 @@ export abstract class FabBaseComboBoxComponent extends ReactWrapperComponent<ICo
     super(elementRef, changeDetectorRef, renderer);
 
     // coming from React context - we need to bind to this so we can access the Angular Component properties
-    this.onChangedHandler = this.onChangedHandler.bind(this);
+    this.onChangeHandler = this.onChangeHandler.bind(this);
     this.onPendingValueChangedHandler = this.onPendingValueChangedHandler.bind(this);
     this.onScrollToItemHandler = this.onScrollToItemHandler.bind(this);
   }
@@ -77,12 +77,12 @@ export abstract class FabBaseComboBoxComponent extends ReactWrapperComponent<ICo
     this.onRenderLowerContent = this.createRenderPropHandler(this.renderLowerContent);
   }
 
-  onChangedHandler(option?: IComboBoxOption, index?: number, value?: string, submitPendingValueEvent?: any) {
-    this.onChanged.emit({
+  onChangeHandler(event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) {
+    this.onChange.emit({
+      event: event.nativeEvent,
       option,
       index,
       value,
-      submitPendingValueEvent,
     });
   }
 

--- a/libs/fabric/src/lib/components/combo-box/combo-box.component.ts
+++ b/libs/fabric/src/lib/components/combo-box/combo-box.component.ts
@@ -28,7 +28,7 @@ import { FabBaseComboBoxComponent } from './base-combo-box.component';
       [isButtonAriaHidden]="isButtonAriaHidden"
       [keytipProps]="keytipProps"
       [RenderLowerContent]="renderLowerContent && onRenderLowerContent"
-      [Changed]="onChangedHandler"
+      [Change]="onChangeHandler"
       [PendingValueChanged]="onPendingValueChangedHandler"
       [ResolveOptions]="resolveOptions"
       [ScrollToItem]="onScrollToItemHandler"

--- a/libs/fabric/src/lib/components/combo-box/virtualized-combo-box.component.ts
+++ b/libs/fabric/src/lib/components/combo-box/virtualized-combo-box.component.ts
@@ -28,7 +28,7 @@ import { FabBaseComboBoxComponent } from './base-combo-box.component';
       [isButtonAriaHidden]="isButtonAriaHidden"
       [keytipProps]="keytipProps"
       [RenderLowerContent]="renderLowerContent && onRenderLowerContent"
-      [Changed]="onChangedHandler"
+      [Change]="onChangeHandler"
       [PendingValueChanged]="onPendingValueChangedHandler"
       [ResolveOptions]="resolveOptions"
       [ScrollToItem]="onScrollToItemHandler"

--- a/libs/fabric/src/lib/components/date-picker/date-picker.component.ts
+++ b/libs/fabric/src/lib/components/date-picker/date-picker.component.ts
@@ -27,6 +27,7 @@ import { IDatePickerProps } from 'office-ui-fabric-react';
       [isRequired]="isRequired"
       [disabled]="disabled"
       [ariaLabel]="ariaLabel"
+      [underlined]="underlined"
       [pickerAriaLabel]="pickerAriaLabel"
       [isMonthPickerVisible]="isMonthPickerVisible"
       [showMonthPickerAsOverlay]="showMonthPickerAsOverlay"
@@ -50,6 +51,8 @@ import { IDatePickerProps } from 'office-ui-fabric-react';
       [minDate]="minDate"
       [maxDate]="maxDate"
       [initialPickerDate]="initialPickerDate"
+      [allFocusable]="allFocusable"
+      [showCloseButton]="showCloseButton"
       [SelectDate]="onSelectDateHandler"
       (onAfterMenuDismiss)="onAfterMenuDismiss.emit()">
     </DatePicker>
@@ -73,6 +76,8 @@ export class FabDatePickerComponent extends ReactWrapperComponent<IDatePickerPro
   disabled?: IDatePickerProps['disabled'];
   @Input()
   ariaLabel?: IDatePickerProps['ariaLabel'];
+  @Input()
+  underlined?: IDatePickerProps['underlined'];
   @Input()
   pickerAriaLabel?: IDatePickerProps['pickerAriaLabel'];
   @Input()
@@ -119,6 +124,10 @@ export class FabDatePickerComponent extends ReactWrapperComponent<IDatePickerPro
   maxDate?: IDatePickerProps['maxDate'];
   @Input()
   initialPickerDate?: IDatePickerProps['initialPickerDate'];
+  @Input()
+  allFocusable?: IDatePickerProps['allFocusable'];
+  @Input()
+  showCloseButton?: IDatePickerProps['showCloseButton'];
 
   @Output()
   readonly onSelectDate = new EventEmitter<{ date: Date | null | undefined }>();

--- a/libs/fabric/src/lib/components/dialog/dialog.component.ts
+++ b/libs/fabric/src/lib/components/dialog/dialog.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IDialogContentProps, IDialogFooterProps, IDialogProps } from 'office-ui-fabric-react/lib/Dialog';
 
 @Component({
@@ -24,6 +34,8 @@ import { IDialogContentProps, IDialogFooterProps, IDialogProps } from 'office-ui
       [dialogContentProps]="dialogContentProps"
       [hidden]="hidden"
       [modalProps]="modalProps"
+      [minWidth]="minWidth"
+      [maxWidth]="maxWidth"
       (onDismiss)="onDismissHandler($event)">
       <ReactContent><ng-content></ng-content></ReactContent>
     </Dialog>
@@ -61,6 +73,10 @@ export class FabDialogComponent extends ReactWrapperComponent<IDialogProps> {
   hidden?: IDialogProps['hidden'];
   @Input()
   modalProps?: IDialogProps['modalProps'];
+  @Input()
+  minWidth?: IDialogProps['minWidth'];
+  @Input()
+  maxWidth?: IDialogProps['maxWidth'];
 
   @Output()
   readonly onDismiss = new EventEmitter<MouseEvent>();

--- a/libs/fabric/src/lib/components/modal/modal.component.ts
+++ b/libs/fabric/src/lib/components/modal/modal.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IAccessiblePopupProps } from 'office-ui-fabric-react/lib/common/IAccessiblePopupProps';
 import { IModalProps } from 'office-ui-fabric-react/lib/Modal';
 import { IWithResponsiveModeState } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
@@ -29,6 +39,7 @@ import { IWithResponsiveModeState } from 'office-ui-fabric-react/lib/utilities/d
       [isBlocking]="isBlocking"
       [className]="className"
       [containerClassName]="containerClassName"
+      [scrollableContentClassName]="scrollableContentClassName"
       [titleAriaId]="titleAriaId"
       [subtitleAriaId]="subtitleAriaId"
       [Dismiss]="onDismissHandler"
@@ -73,6 +84,8 @@ export class FabModalComponent extends ReactWrapperComponent<IModalProps>
   className?: IModalProps['className'];
   @Input()
   containerClassName?: IModalProps['containerClassName'];
+  @Input()
+  scrollableContentClassName?: IModalProps['scrollableContentClassName'];
   @Input()
   titleAriaId?: IModalProps['titleAriaId'];
   @Input()

--- a/libs/fabric/src/lib/components/panel/panel.component.ts
+++ b/libs/fabric/src/lib/components/panel/panel.component.ts
@@ -2,7 +2,18 @@
 // Licensed under the MIT License.
 
 import { InputRendererOptions, JsxRenderFunc, ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IPanelHeaderRenderer, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
 
 @Component({
@@ -19,6 +30,8 @@ import { IPanelHeaderRenderer, IPanelProps } from 'office-ui-fabric-react/lib/Pa
       [isBlocking]="isBlocking"
       [isFooterAtBottom]="isFooterAtBottom"
       [headerText]="headerText"
+      [styles]="styles"
+      [theme]="theme"
       [className]="className"
       [type]="type"
       [customWidth]="customWidth"
@@ -36,7 +49,7 @@ import { IPanelHeaderRenderer, IPanelProps } from 'office-ui-fabric-react/lib/Pa
       [RenderBody]="renderBody && onRenderBody"
       [RenderFooter]="renderFooter && onRenderFooter"
       [RenderFooterContent]="renderFooterContent && onRenderFooterContent"
-      (onDismiss)="onDismiss.emit($event)"
+      [Dismiss]="onDismissHandler"
       (onDismissed)="onDismissed.emit($event)"
       (onLightDismissClick)="onLightDismissClick.emit($event)">
         <ReactContent><ng-content></ng-content></ReactContent>
@@ -65,6 +78,10 @@ export class FabPanelComponent extends ReactWrapperComponent<IPanelProps> implem
   isFooterAtBottom?: IPanelProps['isFooterAtBottom'];
   @Input()
   headerText?: IPanelProps['headerText'];
+  @Input()
+  styles?: IPanelProps['styles'];
+  @Input()
+  theme?: IPanelProps['theme'];
   @Input()
   className?: IPanelProps['className'];
   @Input()
@@ -104,7 +121,7 @@ export class FabPanelComponent extends ReactWrapperComponent<IPanelProps> implem
   @Output()
   readonly onLightDismissClick = new EventEmitter<void>();
   @Output()
-  readonly onDismiss = new EventEmitter<void>();
+  readonly onDismiss = new EventEmitter<{ ev?: Event }>();
   @Output()
   readonly onDismissed = new EventEmitter<void>();
 
@@ -119,6 +136,7 @@ export class FabPanelComponent extends ReactWrapperComponent<IPanelProps> implem
 
     // coming from React context - we need to bind to this so we can access the Angular Component properties
     this.onRenderHeader = this.onRenderHeader.bind(this);
+    this.onDismissHandler = this.onDismissHandler.bind(this);
   }
 
   ngOnInit() {
@@ -139,6 +157,12 @@ export class FabPanelComponent extends ReactWrapperComponent<IPanelProps> implem
     }
 
     return this._renderHeader({ props, headerTextId });
+  }
+
+  onDismissHandler(ev?: React.SyntheticEvent<HTMLElement>) {
+    this.onDismiss.emit({
+      ev: ev && ev.nativeEvent,
+    });
   }
 }
 

--- a/libs/fabric/src/lib/components/panel/panel.module.ts
+++ b/libs/fabric/src/lib/components/panel/panel.module.ts
@@ -4,13 +4,8 @@
 import { registerElement } from '@angular-react/core';
 import { CommonModule } from '@angular/common';
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import * as PanelCss from 'office-ui-fabric-react/lib-amd/components/Panel/Panel.scss';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { noop } from '../../utils/noop';
 import { FabPanelComponent } from './panel.component';
-
-// Dummy action to force PanelCss to load and not be tree-shaken away.
-noop(PanelCss);
 
 const components = [FabPanelComponent];
 

--- a/libs/fabric/src/lib/components/search-box/search-box.component.ts
+++ b/libs/fabric/src/lib/components/search-box/search-box.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { InputRendererOptions, Omit, ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { ISearchBoxProps } from 'office-ui-fabric-react/lib/SearchBox';
 import omit from '../../utils/omit';
@@ -19,6 +29,7 @@ import omit from '../../utils/omit';
       [className]="className"
       [ariaLabel]="ariaLabel"
       [clearButtonProps]="clearButtonProps"
+      [iconProps]="iconProps"
       [underlined]="underlined"
       [theme]="theme"
       [styles]="styles"
@@ -66,6 +77,9 @@ export class FabSearchBoxComponent extends ReactWrapperComponent<ISearchBoxProps
   get clearButtonOptions(): IButtonOptions {
     return this._clearButtonOptions;
   }
+
+  @Input()
+  iconProps?: ISearchBoxProps['iconProps'];
 
   @Output()
   readonly onChange = new EventEmitter<{ newValue: any }>();

--- a/libs/fabric/src/lib/components/slider/slider.component.ts
+++ b/libs/fabric/src/lib/components/slider/slider.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { ISliderProps } from 'office-ui-fabric-react/lib/Slider';
 
 @Component({
@@ -27,6 +37,7 @@ import { ISliderProps } from 'office-ui-fabric-react/lib/Slider';
       [disabled]="disabled"
       [className]="className"
       [buttonProps]="buttonProps"
+      [Changed]="onChangedHandler"
       (onChange)="onChange.emit($event)">
     </Slider>
   `,
@@ -72,8 +83,19 @@ export class FabSliderComponent extends ReactWrapperComponent<ISliderProps> {
 
   @Output()
   readonly onChange = new EventEmitter<number>();
+  @Output()
+  readonly onChanged = new EventEmitter<{ event: MouseEvent | TouchEvent; value: number }>();
 
   constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, renderer: Renderer2) {
     super(elementRef, changeDetectorRef, renderer);
+
+    this.onChangedHandler = this.onChangedHandler.bind(this);
+  }
+
+  onChangedHandler(event: MouseEvent | TouchEvent, value: number) {
+    this.onChanged.emit({
+      event,
+      value,
+    });
   }
 }

--- a/libs/fabric/src/lib/components/toggle/toggle.component.ts
+++ b/libs/fabric/src/lib/components/toggle/toggle.component.ts
@@ -2,7 +2,17 @@
 // Licensed under the MIT License.
 
 import { ReactWrapperComponent } from '@angular-react/core';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, Output, Renderer2, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  Renderer2,
+  ViewChild,
+} from '@angular/core';
 import { IToggleProps } from 'office-ui-fabric-react/lib/Toggle';
 
 @Component({
@@ -15,15 +25,14 @@ import { IToggleProps } from 'office-ui-fabric-react/lib/Toggle';
       [label]="label"
       [Text]="onText"
       [offText]="offText"
-      [AriaLabel]="onAriaLabel"
-      [offAriaLabel]="offAriaLabel"
+      [ariaLabel]="ariaLabel"
       [checked]="checked"
       [defaultChecked]="defaultChecked"
       [disabled]="disabled"
       [theme]="theme"
       [styles]="styles"
       [keytipProps]="keytipProps"
-      (onChanged)="onChanged.emit($event)">
+      [Change]="onChangeHandler">
     </Toggle>
   `,
   styles: ['react-renderer'],
@@ -48,15 +57,9 @@ export class FabToggleComponent extends ReactWrapperComponent<IToggleProps> {
   onText?: IToggleProps['onText'];
   @Input()
   offText?: IToggleProps['offText'];
-
-  /**
-   * Counterpart of `IToggleProps['onAriaLabel']`.
-   * Angular doesn't allow Inputs to be prefixed with "on", so this is misspelled as "onn".
-   */
-  @Input('onnAriaLabel')
-  onAriaLabel?: IToggleProps['onAriaLabel'];
   @Input()
-  offAriaLabel?: IToggleProps['offAriaLabel'];
+  ariaLabel?: IToggleProps['ariaLabel'];
+
   @Input()
   checked?: IToggleProps['checked'];
   @Input()
@@ -71,9 +74,18 @@ export class FabToggleComponent extends ReactWrapperComponent<IToggleProps> {
   keytipProps?: IToggleProps['keytipProps'];
 
   @Output()
-  readonly onChanged = new EventEmitter<boolean>();
+  readonly onChange = new EventEmitter<{ event: MouseEvent; checked?: boolean }>();
 
   constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, renderer: Renderer2) {
     super(elementRef, changeDetectorRef, renderer);
+
+    this.onChangeHandler = this.onChangeHandler.bind(this);
+  }
+
+  onChangeHandler(event: React.MouseEvent<HTMLElement>, checked?: boolean) {
+    this.onChange.emit({
+      event: event && event.nativeEvent,
+      checked,
+    });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1402,9 +1402,9 @@
       }
     },
     "@microsoft/load-themed-styles": {
-      "version": "1.7.73",
-      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.7.73.tgz",
-      "integrity": "sha1-dx/vP43UY3ZEPaYEDHXBlmfZk0g="
+      "version": "1.8.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/load-themed-styles/-/load-themed-styles-1.8.13.tgz",
+      "integrity": "sha512-j6OLXy0sF4lG0EHa02rAhqppwrg5CnqlmoBCRt4yIzApeOPYfdoYbBJhZuka6k++SCymqjatKFT4N/fERofoDA=="
     },
     "@ngrx/effects": {
       "version": "6.0.1",
@@ -2426,11 +2426,6 @@
       "integrity": "sha512-6Qnb1gXbp3g1JX9QVJj3A6ORzc9XCyhokxUKaoonHgNXcQhmk8adhotxfkeK8El9TnFeUuH72yI6jQ5nDJKS6w==",
       "dev": true
     },
-    "@types/prop-types": {
-      "version": "15.5.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.3.tgz",
-      "integrity": "sha512-sfjHrNF4zWRv3fJUGyZW46wVxhYJ/GeWIPdKxbnLIhY3bWR0Ncl2kIhZI7rpjY9KtUQAkDP8jWEmaGQGFFvruA=="
-    },
     "@types/q": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
@@ -2469,40 +2464,51 @@
       "dev": true
     },
     "@uifabric/icons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.0.2.tgz",
-      "integrity": "sha512-M8xfGdxEOUQJ8XQnviFFvystaiy1Ox08ml1WVw+IWhycG7s6eh/vy/WU5kYlECCHcDmGGR0laGT5Jd60Jrfdsg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-6.1.1.tgz",
+      "integrity": "sha512-s0tQHNUYMsWU9pyMPlBY3iCWRXJyzMMbRgdW7djPFuNxaFIjMgjMIWaE6nVkvNz27btAp/h31SzL00+3wCiPwg==",
       "requires": {
-        "@uifabric/styling": ">=6.3.0 <7.0.0",
+        "@uifabric/set-version": ">=1.1.0 <2.0.0",
+        "@uifabric/styling": ">=6.27.0 <7.0.0",
         "tslib": "^1.7.1"
       }
     },
     "@uifabric/merge-styles": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.7.0.tgz",
-      "integrity": "sha512-0aYPw5OlUo6axDlm29LHZyFeJF5h8FQ4S2oOkP/xFn18754+nexCphV00lEZB8GUlawwbTCTicjBis4lxLm1nA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@uifabric/merge-styles/-/merge-styles-6.9.1.tgz",
+      "integrity": "sha512-tq0+A4QRh7u2G+m7YaCNPhYRmwR+dHW+qa3AFufmMnJdKg+YV9jqP8BDI6zejAqpKzUM+j5+LXiQK0VXiRSPWg==",
+      "requires": {
+        "@uifabric/set-version": ">=1.1.0 <2.0.0",
+        "tslib": "^1.7.1"
+      }
+    },
+    "@uifabric/set-version": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/set-version/-/set-version-1.1.0.tgz",
+      "integrity": "sha512-nGLdr2CIetg3SK2Veg2cFpxODPcAaqXxdP2rMOAsUEPsiIAP1RyFFZqIs3K/5gRV8V3tl4vUrtojZs4UGNQrRw==",
       "requires": {
         "tslib": "^1.7.1"
       }
     },
     "@uifabric/styling": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.12.0.tgz",
-      "integrity": "sha512-9au+NXIBOfwlzbjxnj9NfD0lawcm8xLGr6KrgfQStgKp2D01t4drNxRGcpb8UDx7+TgjW6qayErDZPS6z7xWEQ==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-6.27.0.tgz",
+      "integrity": "sha512-0ODb3JySPpSzgDM+zKKAMvqpA7hrzerGD4OQvqwxUKpoGZUIDMcb6W15G2N6WLULLFhDuEv0xuSuV4lJTNoHtQ==",
       "requires": {
         "@microsoft/load-themed-styles": "^1.7.13",
-        "@uifabric/merge-styles": ">=6.5.1 <7.0.0",
-        "@uifabric/utilities": ">=6.12.0 <7.0.0",
+        "@uifabric/merge-styles": ">=6.9.1 <7.0.0",
+        "@uifabric/set-version": ">=1.1.0 <2.0.0",
+        "@uifabric/utilities": ">=6.21.0 <7.0.0",
         "tslib": "^1.7.1"
       }
     },
     "@uifabric/utilities": {
-      "version": "6.12.1",
-      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.12.1.tgz",
-      "integrity": "sha512-smH/ITmdULk58EGgpuiby/yZAcZ+u06I1yBu9ZqE1S+boXUr+eeKxCZqgOrMZJWPq/gOGogjFxd9x7dN4ygW7g==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-6.21.0.tgz",
+      "integrity": "sha512-D3tKr7DyeTkgxwjYf7Ca0xHH4+ClaOf1iCFItJJ7dICrjL04BeHqWjWVTDuCoKFEdyBhqI2z11Th5FdMbzRSKg==",
       "requires": {
-        "@types/prop-types": "^15.5.2",
-        "@uifabric/merge-styles": ">=6.6.0 <7.0.0",
+        "@uifabric/merge-styles": ">=6.9.1 <7.0.0",
+        "@uifabric/set-version": ">=1.1.0 <2.0.0",
         "prop-types": "^15.5.10",
         "tslib": "^1.7.1"
       }
@@ -11069,16 +11075,16 @@
       "dev": true
     },
     "office-ui-fabric-react": {
-      "version": "6.43.0",
-      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.43.0.tgz",
-      "integrity": "sha512-kJDpJgHMyc4dAntT7jBsk4LF07e/8TlLGn4TxOtKDWkMQFmbJbFCzFXqx4DEPwHeJSXGh8VVoePPU4upuhGz9Q==",
+      "version": "6.73.0",
+      "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-6.73.0.tgz",
+      "integrity": "sha512-hBYy8Qmi51me7hfKhP3jq3+5FEs7eh+PqtU7B6ycmUDLjnt6Xd1MFmaCqkmWYFNYcG9IjnXjY8VGK2VBtPBixg==",
       "requires": {
         "@microsoft/load-themed-styles": "^1.7.13",
-        "@types/prop-types": "15.5.3",
-        "@uifabric/icons": ">=6.0.2 <7.0.0",
-        "@uifabric/merge-styles": ">=6.7.0 <7.0.0",
-        "@uifabric/styling": ">=6.12.0 <7.0.0",
-        "@uifabric/utilities": ">=6.12.1 <7.0.0",
+        "@uifabric/icons": ">=6.1.1 <7.0.0",
+        "@uifabric/merge-styles": ">=6.9.1 <7.0.0",
+        "@uifabric/set-version": ">=1.1.0 <2.0.0",
+        "@uifabric/styling": ">=6.27.0 <7.0.0",
+        "@uifabric/utilities": ">=6.21.0 <7.0.0",
         "prop-types": "^15.5.10",
         "tslib": "^1.7.1"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@ngrx/store-devtools": "6.0.1",
     "core-js": "^2.5.4",
     "ngrx-store-freeze": "^0.2.1",
-    "office-ui-fabric-react": "6.43.0",
+    "office-ui-fabric-react": "6.73.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "rxjs": "6.2.2",


### PR DESCRIPTION
Updates `office-ui-fabric-react` to 6.73.0.

Note that this is a breaking change, since some props were marked as `@deprecated` and thus removed from their `@angular-react/fabric`'s counterparts to reduce discrepancy in the future, as was done in the past with such props.