### PR TITLE
Add SSH deploy key to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
     working_directory: ~/repo
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - '3a:38:3d:25:c1:1e:d8:ec:69:a0:13:3c:c6:c9:24:a9'
       - checkout
 
       # Download and cache dependencies


### PR DESCRIPTION
To fix the failing publish docs job in CircleCI.