### PR TITLE
Add declarative syntax to menu items in fab-*-buttons

### DIFF
--- a/libs/fabric/src/lib/components/command-bar/command-bar.component.ts
+++ b/libs/fabric/src/lib/components/command-bar/command-bar.component.ts
@@ -198,10 +198,9 @@ export class FabCommandBarComponent extends ReactWrapperComponent<ICommandBarPro
     return Object.assign(
       {},
       sharedProperties,
-      iconRenderer &&
-        ({
-          onRenderIcon: (item: IContextualMenuItem) => iconRenderer({ contextualMenuItem: item }),
-        } as any) /* NOTE: Fix for wrong typings of `onRenderIcon` in office-ui-fabric-react */,
+      iconRenderer && {
+        onRenderIcon: (item: IContextualMenuItem) => iconRenderer({ contextualMenuItem: item }),
+      },
       renderer &&
         ({ onRender: (item, dismissMenu) => renderer({ item, dismissMenu }) } as Pick<ICommandBarItemProps, 'onRender'>)
     ) as ICommandBarItemProps;

--- a/libs/fabric/src/lib/components/command-bar/directives/command-bar-item.directives.ts
+++ b/libs/fabric/src/lib/components/command-bar/directives/command-bar-item.directives.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AfterContentInit, ContentChild, Directive, Input, TemplateRef } from '@angular/core';
+import { ContentChild, Directive, Input, TemplateRef } from '@angular/core';
 import { ContextualMenuItemDirective } from '../../contextual-menu/directives/contextual-menu-item.directive';
 import { ItemChangedPayload } from '../../core/declarative/item-changed.payload';
 import {
@@ -29,11 +29,7 @@ export class CommandBarItemRenderIconDirective {
 }
 
 @Directive({ selector: 'fab-command-bar-item' })
-export class CommandBarItemDirective extends ContextualMenuItemDirective
-  implements ICommandBarItemOptions, AfterContentInit {
-  @ContentChild(CommandBarItemRenderDirective) readonly renderDirective: CommandBarItemRenderDirective;
-  @ContentChild(CommandBarItemRenderIconDirective) readonly renderIconDirective: CommandBarItemRenderIconDirective;
-
+export class CommandBarItemDirective extends ContextualMenuItemDirective implements ICommandBarItemOptions {
   // ICommandBarItemOptions implementation
   @Input() iconOnly?: ICommandBarItemOptions['iconOnly'];
   @Input() tooltipHostProps?: ICommandBarItemOptions['tooltipHostProps'];
@@ -41,18 +37,4 @@ export class CommandBarItemDirective extends ContextualMenuItemDirective
   @Input() cacheKey?: ICommandBarItemOptions['cacheKey'];
   @Input() renderedInOverflow?: ICommandBarItemOptions['renderedInOverflow'];
   @Input() commandBarButtonAs?: ICommandBarItemOptions['commandBarButtonAs'];
-  @Input() render: ICommandBarItemOptions['render'];
-  @Input() renderIcon: ICommandBarItemOptions['renderIcon'];
-
-  ngAfterContentInit() {
-    super.ngAfterContentInit();
-
-    if (this.renderDirective && this.renderDirective.templateRef) {
-      this.render = this.renderDirective.templateRef;
-    }
-
-    if (this.renderIconDirective && this.renderIconDirective.templateRef) {
-      this.renderIcon = this.renderIconDirective.templateRef;
-    }
-  }
 }

--- a/libs/fabric/src/lib/components/contextual-menu/contextual-menu.module.ts
+++ b/libs/fabric/src/lib/components/contextual-menu/contextual-menu.module.ts
@@ -3,9 +3,17 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
-import { ContextualMenuItemDirective } from './directives/contextual-menu-item.directive';
+import {
+  ContextualMenuItemDirective,
+  ContextualMenuItemRenderDirective,
+  ContextualMenuItemRenderIconDirective,
+} from './directives/contextual-menu-item.directive';
 
-const components = [ContextualMenuItemDirective];
+const components = [
+  ContextualMenuItemDirective,
+  ContextualMenuItemRenderDirective,
+  ContextualMenuItemRenderIconDirective,
+];
 
 @NgModule({
   imports: [CommonModule],

--- a/libs/fabric/src/lib/components/contextual-menu/directives/contextual-menu-item.directive.ts
+++ b/libs/fabric/src/lib/components/contextual-menu/directives/contextual-menu-item.directive.ts
@@ -13,7 +13,7 @@ import {
   ContentChild,
   TemplateRef,
 } from '@angular/core';
-import { IContextualMenuItem, IContextualMenuItemProps } from 'office-ui-fabric-react';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
 import { KnownKeys, InputRendererOptions } from '@angular-react/core';
 
 import { OnChanges } from '../../../declarations/angular/typed-changes';
@@ -93,15 +93,15 @@ export class ContextualMenuItemDirective extends ChangeableItemDirective<IContex
 
   @Output()
   get onChildItemChanged(): EventEmitter<ItemChangedPayload<string, IContextualMenuItem>> {
-    return this.changeableItemsHelper && this.changeableItemsHelper.onChildItemChanged;
+    return this._changeableItemsHelper && this._changeableItemsHelper.onChildItemChanged;
   }
 
   @Output()
   get onItemsChanged(): EventEmitter<QueryList<ChangeableItemDirective<IContextualMenuItem>>> {
-    return this.changeableItemsHelper && this.changeableItemsHelper.onItemsChanged;
+    return this._changeableItemsHelper && this._changeableItemsHelper.onItemsChanged;
   }
 
-  private changeableItemsHelper: ChangeableItemsHelper<IContextualMenuItem>;
+  private _changeableItemsHelper: ChangeableItemsHelper<IContextualMenuItem>;
 
   ngAfterContentInit() {
     if (this.renderDirective && this.renderDirective.templateRef) {
@@ -112,7 +112,7 @@ export class ContextualMenuItemDirective extends ChangeableItemDirective<IContex
       this.renderIcon = this.renderIconDirective.templateRef;
     }
 
-    this.changeableItemsHelper = new ChangeableItemsHelper(this.menuItemsDirectives, this, nonSelfDirective => {
+    this._changeableItemsHelper = new ChangeableItemsHelper(this.menuItemsDirectives, this, nonSelfDirective => {
       const items = nonSelfDirective.map(directive => this._directiveToContextualMenuItem(directive as any));
       if (!this.subMenuProps) {
         this.subMenuProps = { items: items };
@@ -123,7 +123,7 @@ export class ContextualMenuItemDirective extends ChangeableItemDirective<IContex
   }
 
   ngOnDestroy() {
-    this.changeableItemsHelper.destroy();
+    this._changeableItemsHelper.destroy();
   }
 
   private _directiveToContextualMenuItem(directive: ContextualMenuItemDirective): IContextualMenuItem {


### PR DESCRIPTION
This PR aims to add a declarative syntax to all `fab-*-button`s components (`fab-default-button`, `fab-action-button` etc.) for declaring menu items:
```html
<fab-default-button text="Contact me">
  <contextual-menu-item key="email" text="Email" (click)="sendEmail()"></contextual-menu-item>
  <contextual-menu-item key="phone" text="Phone" (click)="call()"></contextual-menu-item>
</fab-default-button>
```

Also addresses `<contextual-menu-item>` directive items not having a comparable declarative syntax for their `render` and `renderIcon` inputs counterparts in `IContextualMenuItem`. Note that the overriding of an icon render doesn't work due to a bug in `office-ui-fabric-react`.

---

Related issue: #3