### PR TITLE
add rxjs as core package peerDependency

### DIFF
--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -54,6 +54,7 @@
     "@angular/core": "^7.0.3",
     "@angular/platform-browser-dynamic": "^7.0.3",
     "@angular/platform-browser": "^7.0.3",
+    "rxjs": "^6.2.0",
     "react-dom": "^16.6.3",
     "react": "^16.6.3"
   },


### PR DESCRIPTION
Was already being implicitly required since `@angular/core` was a peer dependency, but we use it explicitly in the code, so it should be explicitly present.