### PR TITLE
Fix MessageBar always passing actions, even when non were supplied

### DIFF
--- a/apps/demo/src/app/app.component.html
+++ b/apps/demo/src/app/app.component.html
@@ -9,6 +9,17 @@
   </ol>
 </div>
 
+<div style="width:500px">
+  <fab-message-bar>
+    Lorem, ipsum dolor sit amet consectetur adipisicing elit. Autem laboriosam id ad mollitia optio saepe qui aliquid
+    facere, porro maiores voluptas, aliquam totam adipisci molestias illum dolorem accusamus. Quam, nisi. Lorem ipsum
+    dolor sit amet consectetur, adipisicing elit. Suscipit dolores architecto illo reprehenderit fugiat dolorum sapiente
+    modi placeat ex nostrum, illum esse iusto commodi neque corrupti labore nam voluptatum nisi? Lorem ipsum dolor sit,
+    amet consectetur adipisicing elit. Animi, impedit dolore aliquid voluptate debitis recusandae officiis qui
+    blanditiis soluta ea delectus culpa molestiae enim quo, quibusdam exercitationem magni nemo amet!
+  </fab-message-bar>
+</div>
+
 <fab-dropdown
   [label]="'test label'"
   [selectedKey]="selectedItem && selectedItem.key"
@@ -19,7 +30,12 @@
   (onBlur)="logEvent('dropdown blur', $event)"
 ></fab-dropdown>
 
-<fab-dropdown contentStyle="width: 300px;" [placeholder]="'Select one'" [defaultSelectedKey]="'A'" (onChange)="logEvent('dropdown change', $event)">
+<fab-dropdown
+  contentStyle="width: 300px;"
+  [placeholder]="'Select one'"
+  [defaultSelectedKey]="'A'"
+  (onChange)="logEvent('dropdown change', $event)"
+>
   <options>
     <fab-dropdown-option optionKey="A" text="See option A"></fab-dropdown-option>
     <fab-dropdown-option optionKey="B" text="See option B"></fab-dropdown-option>

--- a/libs/fabric/src/lib/components/message-bar/message-bar.component.ts
+++ b/libs/fabric/src/lib/components/message-bar/message-bar.component.ts
@@ -33,7 +33,7 @@ import { IMessageBarProps } from 'office-ui-fabric-react/lib/MessageBar';
       [theme]="theme"
       [styles]="styles"
       [Dismiss]="onDismissInternal"
-      [actions]="actions"
+      [actions]="renderActions && actions"
     >
       <ReactContent><ng-content></ng-content></ReactContent>
     </MessageBar>


### PR DESCRIPTION
Fix for `fab-message-bar` passing `actions` to `MessageBar`, even when non were supplied.
This caused styling issues (since the `MessageBar` changes the styling based on the presence of `actions`).