### PR TITLE
fix|remove componentRef prop from Image, Callout

### DIFF
--- a/libs/fabric/package.json
+++ b/libs/fabric/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/package.schema.json",
   "name": "@angular-react/fabric",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "ngPackage": {
     "lib": {
       "entryFile": "public-api.ts",

--- a/libs/fabric/src/lib/components/callout/callout.component.ts
+++ b/libs/fabric/src/lib/components/callout/callout.component.ts
@@ -22,7 +22,6 @@ import { ICalloutPositionedInfo } from 'office-ui-fabric-react/lib/utilities/pos
   template: `
     <Callout
       #reactNode
-      [componentRef]="componentRef"
       [target]="target"
       [directionalHint]="directionalHint"
       [directionalHintForRTL]="directionalHintForRTL"

--- a/libs/fabric/src/lib/components/image/image.component.ts
+++ b/libs/fabric/src/lib/components/image/image.component.ts
@@ -22,7 +22,6 @@ import { IImageProps, ImageLoadState } from 'office-ui-fabric-react/lib/Image';
     <!-- prettier-ignore -->
     <Image
       #reactNode
-      [componentRef]="componentRef"
       [alt]="alt"
       [crossOrigin]="crossOrigin"
       [height]="height"


### PR DESCRIPTION
it was removed from office-ui-fabric-react
sometime between 6.151.0 and 6.200.0