### PR TITLE
fix(PivotItem): onRenderItemLink cannot pass to office-ui-fabric-react

### DIFF
--- a/libs/fabric/src/lib/components/pivot/pivot.component.ts
+++ b/libs/fabric/src/lib/components/pivot/pivot.component.ts
@@ -63,7 +63,7 @@ export class FabPivotItemComponent extends ReactWrapperComponent<IPivotItemProps
 
   @Input() @passProp() renderItemLink?: InputRendererOptions<IPivotItemProps>;
 
-  onRenderItemLink: (props?: IPivotItemProps, defaultRender?: JsxRenderFunc<IPivotItemProps>) => JSX.Element;
+  @passProp() onRenderItemLink: (props?: IPivotItemProps, defaultRender?: JsxRenderFunc<IPivotItemProps>) => JSX.Element;
 
   constructor(elementRef: ElementRef, changeDetectorRef: ChangeDetectorRef, renderer: Renderer2, ngZone: NgZone) {
     super(elementRef, changeDetectorRef, renderer, { ngZone, setHostDisplay: true });


### PR DESCRIPTION
I just find a problem when I try `Pivot`. The property `onRenderItemLink` defined in `FabPivotItemComponent` cannot pass to `office-ui-fabric-react` if I use `renderItemLink` the customize what to render.  
So I try this way to resolve the problem.